### PR TITLE
assign the responsibility of the default alliance color to Field2d

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -1,5 +1,10 @@
 {
   "HALProvider": {
+    "Addressable LEDs": {
+      "window": {
+        "visible": true
+      }
+    },
     "DIO": {
       "window": {
         "visible": true

--- a/src/main/java/frc/lib/team3061/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/lib/team3061/drivetrain/Drivetrain.java
@@ -113,7 +113,7 @@ public class Drivetrain extends SubsystemBase {
   private ChassisSpeeds prevSpeeds = new ChassisSpeeds();
   private double[] prevSteerVelocitiesRevPerMin = new double[4];
 
-  private DriverStation.Alliance alliance = DriverStation.Alliance.Red;
+  private DriverStation.Alliance alliance = Field2d.getInstance().getAlliance();
 
   private Pose2d prevRobotPose = new Pose2d();
   private int teleportedCount = 0;

--- a/src/main/java/frc/lib/team3061/leds/LEDs.java
+++ b/src/main/java/frc/lib/team3061/leds/LEDs.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.lib.team3061.RobotConfig;
+import frc.robot.Field2d;
 import java.util.List;
 
 @java.lang.SuppressWarnings({"java:S6548"})
@@ -42,7 +43,6 @@ public abstract class LEDs extends SubsystemBase {
   private boolean demoMode = false;
 
   private boolean assignedAlliance = false;
-  private Alliance alliance = Alliance.Blue;
   private boolean lastEnabledAuto = false;
   private double lastEnabledTime = 0.0;
   private boolean estopped = false;
@@ -215,7 +215,7 @@ public abstract class LEDs extends SubsystemBase {
 
   private void updateToDisabledPattern() {
     if (assignedAlliance) {
-      if (alliance == Alliance.Red) {
+      if (Field2d.getInstance().getAlliance() == Alliance.Red) {
         wave(
             Section.FULL,
             Color.kRed,
@@ -259,7 +259,7 @@ public abstract class LEDs extends SubsystemBase {
             new Color(0.15, 0.3, 1.0)),
         3,
         5.0);
-    switch (alliance) {
+    switch (Field2d.getInstance().getAlliance()) {
       case Red:
         solid(Section.STATIC_LOW, Color.kRed);
         break;
@@ -272,9 +272,8 @@ public abstract class LEDs extends SubsystemBase {
   }
 
   private void updateState() {
-    // Update alliance color
+    // check for alliance assignment when connected to FMS
     if (DriverStation.isFMSAttached()) {
-      alliance = DriverStation.getAlliance().orElse(Alliance.Blue);
       assignedAlliance = true;
     } else {
       assignedAlliance = false;

--- a/src/main/java/frc/robot/Field2d.java
+++ b/src/main/java/frc/robot/Field2d.java
@@ -35,7 +35,7 @@ public class Field2d {
 
   private Region2d[] regions;
 
-  private Alliance alliance;
+  private Alliance alliance = DriverStation.Alliance.Blue;
 
   private static final double AMP_SCORING_ALIGNMENT_OFFSET = -0.1;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -76,7 +76,7 @@ public class RobotContainer {
   private OperatorInterface oi = new OperatorInterface() {};
   private RobotConfig config;
   private Drivetrain drivetrain;
-  private Alliance lastAlliance = DriverStation.Alliance.Red;
+  private Alliance lastAlliance = Field2d.getInstance().getAlliance();
   private Vision vision;
   private NoteTargeting noteTargeting;
   private Shooter shooter;


### PR DESCRIPTION
Multiple classes had default values for the alliance color. This was a bug waiting to impact us if they ever got out of sync. Assign the responsibility for tracking the default alliance color to the Field2d class.