### PR TITLE
refactor LED subsystem to use a Tree Set to prioritize states

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -1,6 +1,9 @@
 {
   "HALProvider": {
     "Addressable LEDs": {
+      "0": {
+        "columns": 35
+      },
       "window": {
         "visible": true
       }

--- a/src/main/java/frc/lib/team3061/leds/LEDs.java
+++ b/src/main/java/frc/lib/team3061/leds/LEDs.java
@@ -62,18 +62,9 @@ public abstract class LEDs extends SubsystemBase {
             leds.solid(
                 1.0 - ((Timer.getFPGATimestamp() - leds.lastEnabledTime) / AUTO_FADE_TIME),
                 Color.kGreen)),
-    DISABLED_DEMO_MODE((leds, section) -> leds.updateToPridePattern()),
     LOW_BATTERY((leds, section) -> leds.solid(section, new Color(255, 20, 0))),
     DISABLED((leds, section) -> leds.updateToDisabledPattern(section)),
     AUTO((leds, section) -> leds.orangePulse(section, PULSE_DURATION)),
-    TELEOP_DEMO_MODE(
-        (leds, section) ->
-            leds.wave(
-                section,
-                new Color(255, 30, 0),
-                Color.kDarkBlue,
-                WAVE_SLOW_CYCLE_LENGTH,
-                WAVE_MEDIUM_DURATION)),
     ENDGAME_ALERT((leds, section) -> leds.strobe(section, Color.kYellow, STROBE_SLOW_DURATION)),
     SHOOTING((leds, section) -> leds.strobe(section, Color.kGreen, STROBE_SLOW_DURATION)),
     AIMING_AT_SPEAKER((leds, section) -> leds.solid(section, Color.kGreen)),
@@ -90,6 +81,16 @@ public abstract class LEDs extends SubsystemBase {
                 WAVE_SLOW_DURATION)),
     MANUAL_REPEL((leds, section) -> leds.strobe(section, Color.kDeepPink, STROBE_SLOW_DURATION)),
     INTAKE_MANUALLY_TURNED_OFF((leds, section) -> leds.solid(section, Color.kYellow)),
+    TELEOP_DEMO_MODE(
+        (leds, section) ->
+            leds.wave(
+                section,
+                new Color(255, 30, 0),
+                Color.kDarkBlue,
+                WAVE_SLOW_CYCLE_LENGTH,
+                WAVE_MEDIUM_DURATION)),
+    
+                DISABLED_DEMO_MODE((leds, section) -> leds.updateToPridePattern()),
     DEFAULT((leds, section) -> leds.solid(section, Color.kBlack));
 
     public final BiConsumer<LEDs, Section> setter;

--- a/src/main/java/frc/lib/team3061/leds/LEDs.java
+++ b/src/main/java/frc/lib/team3061/leds/LEDs.java
@@ -63,6 +63,7 @@ public abstract class LEDs extends SubsystemBase {
                 1.0 - ((Timer.getFPGATimestamp() - leds.lastEnabledTime) / AUTO_FADE_TIME),
                 Color.kGreen)),
     LOW_BATTERY((leds, section) -> leds.solid(section, new Color(255, 20, 0))),
+    DISABLED_DEMO_MODE((leds, section) -> leds.updateToPridePattern()),
     DISABLED((leds, section) -> leds.updateToDisabledPattern(section)),
     AUTO((leds, section) -> leds.orangePulse(section, PULSE_DURATION)),
     ENDGAME_ALERT((leds, section) -> leds.strobe(section, Color.kYellow, STROBE_SLOW_DURATION)),
@@ -81,16 +82,6 @@ public abstract class LEDs extends SubsystemBase {
                 WAVE_SLOW_DURATION)),
     MANUAL_REPEL((leds, section) -> leds.strobe(section, Color.kDeepPink, STROBE_SLOW_DURATION)),
     INTAKE_MANUALLY_TURNED_OFF((leds, section) -> leds.solid(section, Color.kYellow)),
-    TELEOP_DEMO_MODE(
-        (leds, section) ->
-            leds.wave(
-                section,
-                new Color(255, 30, 0),
-                Color.kDarkBlue,
-                WAVE_SLOW_CYCLE_LENGTH,
-                WAVE_MEDIUM_DURATION)),
-    
-                DISABLED_DEMO_MODE((leds, section) -> leds.updateToPridePattern()),
     DEFAULT((leds, section) -> leds.solid(section, Color.kBlack));
 
     public final BiConsumer<LEDs, Section> setter;
@@ -328,12 +319,8 @@ public abstract class LEDs extends SubsystemBase {
     }
 
     // update for demo mode
-    if (Constants.DEMO_MODE) {
-      if (DriverStation.isDisabled()) {
-        this.requestState(States.DISABLED_DEMO_MODE);
-      } else {
-        this.requestState(States.TELEOP_DEMO_MODE);
-      }
+    if (Constants.DEMO_MODE && DriverStation.isDisabled()) {
+      this.requestState(States.DISABLED_DEMO_MODE);
     }
   }
 

--- a/src/main/java/frc/lib/team3061/leds/LEDsRIO.java
+++ b/src/main/java/frc/lib/team3061/leds/LEDsRIO.java
@@ -3,6 +3,7 @@ package frc.lib.team3061.leds;
 import edu.wpi.first.wpilibj.AddressableLED;
 import edu.wpi.first.wpilibj.AddressableLEDBuffer;
 import edu.wpi.first.wpilibj.util.Color;
+import frc.robot.Constants;
 
 public class LEDsRIO extends LEDs {
 
@@ -15,7 +16,7 @@ public class LEDsRIO extends LEDs {
     leds = new AddressableLED(0);
     buffer = new AddressableLEDBuffer(ACTUAL_LENGTH);
     // leds.setBitTiming(500, 200, 1200, 1300);
-    isGRB = true;
+    isGRB = Constants.getMode() != Constants.Mode.SIM;
     competitionBrightness = true;
 
     leds.setLength(ACTUAL_LENGTH);

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -203,7 +203,7 @@ public class Robot extends LoggedRobot {
     }
     if (RobotController.getBatteryVoltage() < LOW_BATTERY_VOLTAGE
         && disabledTimer.hasElapsed(LOW_BATTERY_DISABLED_TIME)) {
-      LEDs.getInstance().setLowBatteryAlert(true);
+      LEDs.getInstance().requestState(LEDs.States.LOW_BATTERY);
       lowBatteryAlert.set(true);
     }
 
@@ -219,7 +219,6 @@ public class Robot extends LoggedRobot {
                 "*** Auto cancelled in %.2f secs ***", Timer.getFPGATimestamp() - autoStart));
       }
       autoMessagePrinted = true;
-      LEDs.getInstance().setAutoFinished(true);
     }
 
     robotContainer.periodic();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -27,7 +27,6 @@ import frc.lib.team3061.drivetrain.swerve.SwerveModuleIO;
 import frc.lib.team3061.drivetrain.swerve.SwerveModuleIOTalonFXPhoenix6;
 import frc.lib.team3061.gyro.GyroIOPigeon2Phoenix6;
 import frc.lib.team3061.leds.LEDs;
-import frc.lib.team3061.leds.LEDs.ShooterLEDState;
 import frc.lib.team3061.vision.Vision;
 import frc.lib.team3061.vision.VisionConstants;
 import frc.lib.team3061.vision.VisionIO;
@@ -356,11 +355,8 @@ public class RobotContainer {
                     && DriverStation.getMatchTime() > 0.0
                     && DriverStation.getMatchTime() <= Math.round(endgameAlert1.get()))
         .onTrue(
-            Commands.run(() -> LEDs.getInstance().setEndgameAlert(true))
-                .withTimeout(1)
-                .andThen(
-                    Commands.run(() -> LEDs.getInstance().setEndgameAlert(false))
-                        .withTimeout(1.0)));
+            Commands.run(() -> LEDs.getInstance().requestState(LEDs.States.ENDGAME_ALERT))
+                .withTimeout(1));
     new Trigger(
             () ->
                 DriverStation.isTeleopEnabled()
@@ -368,10 +364,11 @@ public class RobotContainer {
                     && DriverStation.getMatchTime() <= Math.round(endgameAlert2.get()))
         .onTrue(
             Commands.sequence(
-                Commands.run(() -> LEDs.getInstance().setEndgameAlert(true)).withTimeout(0.5),
-                Commands.run(() -> LEDs.getInstance().setEndgameAlert(false)).withTimeout(0.25),
-                Commands.run(() -> LEDs.getInstance().setEndgameAlert(true)).withTimeout(0.5),
-                Commands.run(() -> LEDs.getInstance().setEndgameAlert(false)).withTimeout(0.25)));
+                Commands.run(() -> LEDs.getInstance().requestState(LEDs.States.ENDGAME_ALERT))
+                    .withTimeout(0.5),
+                Commands.waitSeconds(0.25),
+                Commands.run(() -> LEDs.getInstance().requestState(LEDs.States.ENDGAME_ALERT))
+                    .withTimeout(0.5)));
 
     // interrupt all commands by running a command that requires every subsystem. This is used to
     // recover to a known state if the robot becomes "stuck" in a command.
@@ -981,9 +978,9 @@ public class RobotContainer {
 
   public void periodic() {
     if (this.isReadyToShoot()) {
-      LEDs.getInstance().setShooterLEDState(ShooterLEDState.IS_READY_TO_SHOOT);
+      LEDs.getInstance().requestState(LEDs.States.READY_TO_SHOOT);
     } else if (this.intake.hasNote()) {
-      LEDs.getInstance().setShooterLEDState(ShooterLEDState.AIMING_AT_SPEAKER);
+      LEDs.getInstance().requestState(LEDs.States.AIMING_AT_SPEAKER);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.lib.team3015.subsystem.FaultReporter;
 import frc.lib.team3061.leds.LEDs;
-import frc.lib.team3061.leds.LEDs.IntakeLEDState;
 import frc.lib.team6328.util.TunableNumber;
 import frc.robot.Constants;
 import java.util.ArrayList;
@@ -75,7 +74,7 @@ public class Intake extends SubsystemBase {
 
     quickShootingEnabled = false;
 
-    leds.setIntakeLEDState(IntakeLEDState.WAITING_FOR_GAME_PIECE);
+    leds.requestState(LEDs.States.WAITING_FOR_GAME_PIECE);
     this.intakeGamePiece();
 
     ShuffleboardTab tabMain = Shuffleboard.getTab("MAIN");
@@ -105,7 +104,7 @@ public class Intake extends SubsystemBase {
       io.setRollerVelocity(rollerVelocity.get());
       io.setKickerVoltage(kickerVelocity.get());
     } else if (quickShootingEnabled && DriverStation.isAutonomousEnabled()) {
-      leds.setIntakeLEDState(IntakeLEDState.SHOOTING);
+      leds.requestState(LEDs.States.SHOOTING);
       this.intakeGamePiece();
       this.io.setKickerVoltage(KICKER_SHOOTING_VELOCITY_VOLTAGE);
     } else {
@@ -145,11 +144,11 @@ public class Intake extends SubsystemBase {
 
     if (inputs.isRollerIRBlocked) {
       intakeState = IntakeState.NOTE_IN_INTAKE;
-      leds.setIntakeLEDState(IntakeLEDState.HAS_GAME_PIECE);
+      leds.requestState(LEDs.States.HAS_GAME_PIECE);
       this.transitionGamePiece();
     } else if (inputs.isShooterIRBlocked) {
       intakeState = IntakeState.NOTE_IN_SHOOTER;
-      leds.setIntakeLEDState(IntakeLEDState.HAS_GAME_PIECE);
+      leds.requestState(LEDs.States.HAS_GAME_PIECE);
       this.repelGamePiece();
     }
   }
@@ -179,7 +178,7 @@ public class Intake extends SubsystemBase {
     if (intakeAndKickerTimeout
         > IntakeConstants.IN_BETWEEN_TIMEOUT_SECONDS / Constants.LOOP_PERIOD_SECS) {
       intakeState = IntakeState.EMPTY;
-      leds.setIntakeLEDState(IntakeLEDState.WAITING_FOR_GAME_PIECE);
+      leds.requestState(LEDs.States.WAITING_FOR_GAME_PIECE);
       this.intakeGamePiece();
     } else if (inputs.isKickerIRBlocked) {
       intakeState = IntakeState.NOTE_IN_KICKER;
@@ -206,7 +205,7 @@ public class Intake extends SubsystemBase {
     // shots, the note can move such that it isn't detected by the shooter IR sensor)
     if (!this.hasNote()) {
       intakeState = IntakeState.EMPTY;
-      leds.setIntakeLEDState(IntakeLEDState.WAITING_FOR_GAME_PIECE);
+      leds.requestState(LEDs.States.WAITING_FOR_GAME_PIECE);
       this.turnKickerOff();
       this.intakeGamePiece();
     }
@@ -215,11 +214,11 @@ public class Intake extends SubsystemBase {
   private void runShootingState() {
     if (!this.hasNote()) {
       intakeState = IntakeState.EMPTY;
-      leds.setIntakeLEDState(IntakeLEDState.WAITING_FOR_GAME_PIECE);
+      leds.requestState(LEDs.States.WAITING_FOR_GAME_PIECE);
       this.intakeGamePiece();
       this.turnKickerOff();
     } else {
-      leds.setIntakeLEDState(IntakeLEDState.SHOOTING);
+      leds.requestState(LEDs.States.SHOOTING);
       this.io.setKickerVoltage(KICKER_SHOOTING_VELOCITY_VOLTAGE);
     }
   }

--- a/src/main/java/frc/robot/subsystems/note_targeting/NoteTargeting.java
+++ b/src/main/java/frc/robot/subsystems/note_targeting/NoteTargeting.java
@@ -3,7 +3,6 @@ package frc.robot.subsystems.note_targeting;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.lib.team3061.leds.LEDs;
-import frc.lib.team3061.leds.LEDs.NoteTargetingLEDState;
 import frc.lib.team6328.util.TunableNumber;
 import org.littletonrobotics.junction.Logger;
 
@@ -27,14 +26,10 @@ public class NoteTargeting extends SubsystemBase {
   }
 
   private void handleLEDs() {
-    // we see nothing,  we see it but arent going after it, we are now going after it
+    // we see nothing,  we see it but aren't going after it, we are now going after it
 
     if (targeting) {
-      LEDs.getInstance().setNoteTargetingLEDState(NoteTargetingLEDState.PURSUING_NOTE);
-    } else if (inputs.hasTarget) {
-      LEDs.getInstance().setNoteTargetingLEDState(NoteTargetingLEDState.NOTE_TARGETED);
-    } else {
-      LEDs.getInstance().setNoteTargetingLEDState(NoteTargetingLEDState.NO_NOTE_TARGETED);
+      LEDs.getInstance().requestState(LEDs.States.PURSUING_NOTE);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -13,7 +13,6 @@ import frc.lib.team3015.subsystem.FaultReporter;
 import frc.lib.team3061.drivetrain.Drivetrain;
 import frc.lib.team3061.drivetrain.DrivetrainConstants;
 import frc.lib.team3061.leds.LEDs;
-import frc.lib.team3061.leds.LEDs.ShooterLEDState;
 import frc.lib.team3061.util.RobotOdometry;
 import frc.lib.team6328.util.TunableNumber;
 import frc.robot.Constants;
@@ -47,7 +46,7 @@ public class Shooter extends SubsystemBase {
           "Shooter/DeflectorRetractionDelaySeconds",
           ShooterConstants.DEFLECTOR_RETRACTION_DELAY_SECS);
 
-  // FIXME: tune on the competititon field
+  // FIXME: tune on the competition field
   private static final double FIELD_MEASUREMENT_OFFSET = 0.0;
   private final double[] populationRealAngles = {
     64, 57, 53, 45, 43, 41, 38, 36, 35, 33, 32, 31, 29.5, 29.5, 29, 28, 27.5
@@ -174,11 +173,11 @@ public class Shooter extends SubsystemBase {
     if (state == State.WAITING_FOR_NOTE) {
       if (intake.hasNote()) {
         state = State.AIMING_AT_SPEAKER;
-        leds.setShooterLEDState(ShooterLEDState.AIMING_AT_SPEAKER);
+        leds.requestState(LEDs.States.AIMING_AT_SPEAKER);
       }
       this.moveToIntakePosition();
       this.setIdleVelocity();
-      leds.setShooterLEDState(ShooterLEDState.WAITING_FOR_GAME_PIECE);
+      leds.requestState(LEDs.States.WAITING_FOR_GAME_PIECE);
     } else if (state == State.AIMING_AT_SPEAKER) {
       if (!intake.hasNote()) {
         this.resetToInitialState();


### PR DESCRIPTION
This new approach is based on FRC 6995's use of TreeSet to prioritize LED states as [shared on CD](https://www.chiefdelphi.com/t/enums-and-subsytem-states/463974/31?u=gcschmit). I think this approach will make it easier to add states throughout the season and ensure they are in priority order.

However, I'm not 100% sure; so, please take a look and let me know what you think.