### PR TITLE
disable x-stance at the start of teleop

### DIFF
--- a/src/main/java/frc/lib/team3061/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/lib/team3061/drivetrain/Drivetrain.java
@@ -562,6 +562,8 @@ public class Drivetrain extends SubsystemBase {
     // update the brake mode based on the robot's velocity and state (enabled/disabled)
     updateBrakeMode();
 
+    Logger.recordOutput(SUBSYSTEM_NAME + "/DriveMode", this.driveMode);
+
     // update tunables
     if (autoDriveKp.hasChanged() || autoDriveKi.hasChanged() || autoDriveKd.hasChanged()) {
       autoXController.setPID(autoDriveKp.get(), autoDriveKi.get(), autoDriveKd.get());

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -271,10 +271,7 @@ public class Robot extends LoggedRobot {
       autonomousCommand.cancel();
     }
 
-    // check if the alliance color has changed based on the FMS data; if the robot power cycled
-    // during a match, this would be the first opportunity to check the alliance color based on FMS
-    // data.
-    robotContainer.checkAllianceColor();
+    robotContainer.teleopInit();
   }
 
   /** This method is invoked at the start of the test period. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -992,6 +992,17 @@ public class RobotContainer {
     intake.disableQuickShoot();
   }
 
+  public void teleopInit() {
+    // check if the alliance color has changed based on the FMS data; if the robot power cycled
+    // during a match, this would be the first opportunity to check the alliance color based on FMS
+    // data.
+    this.checkAllianceColor();
+
+    // ensure that x-stance is disabled at the start of teleop as there is a possibility if the
+    //  auto command is interrupted, we could still be in x-stance
+    drivetrain.disableXstance();
+  }
+
   private boolean isReadyToShoot() {
     return shooter.isShooterReadyToShoot(!vision.isEnabled() || drivetrain.isAimedAtSpeaker());
   }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -944,7 +944,8 @@ public class RobotContainer {
                     new TeleopSwerveAimAtSpeaker(drivetrain, shooter, intake, () -> 0.0, () -> 0.0),
                     getShootCommand())
                 .withTimeout(1.0))
-        .andThen(Commands.runOnce(intake::shoot, intake));
+        .andThen(Commands.runOnce(intake::shoot, intake))
+        .finallyDo(drivetrain::disableXstance);
   }
 
   private Command getShootCommand() {


### PR DESCRIPTION
We need to ensure that x-stance is disabled at the start of teleop as there is a possibility if the auto command is interrupted, we could still be in x-stance when tele-op starts. If that happens, we can't get out of it.