### PR TITLE
use slip current swerve module constant property properly

### DIFF
--- a/src/main/java/frc/lib/team3061/drivetrain/DrivetrainIOCTRE.java
+++ b/src/main/java/frc/lib/team3061/drivetrain/DrivetrainIOCTRE.java
@@ -9,7 +9,6 @@ import com.ctre.phoenix6.configs.MountPoseConfigs;
 import com.ctre.phoenix6.configs.Pigeon2Configuration;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.configs.TorqueCurrentConfigs;
 import com.ctre.phoenix6.controls.TorqueCurrentFOC;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.mechanisms.swerve.SwerveDrivetrain;
@@ -142,18 +141,12 @@ public class DrivetrainIOCTRE extends SwerveDrivetrain implements DrivetrainIO {
       new SwerveModuleConstantsFactory()
           .withDriveMotorInitialConfigs(
               new TalonFXConfiguration()
-                  .withTorqueCurrent(
-                      new TorqueCurrentConfigs()
-                          .withPeakForwardTorqueCurrent(SwerveConstants.DRIVE_PEAK_CURRENT_LIMIT)
-                          .withPeakReverseTorqueCurrent(-SwerveConstants.DRIVE_PEAK_CURRENT_LIMIT))
                   .withCurrentLimits(
                       new CurrentLimitsConfigs()
                           .withSupplyCurrentLimit(SwerveConstants.DRIVE_CONTINUOUS_CURRENT_LIMIT)
                           .withSupplyCurrentThreshold(SwerveConstants.DRIVE_PEAK_CURRENT_LIMIT)
                           .withSupplyTimeThreshold(SwerveConstants.DRIVE_PEAK_CURRENT_DURATION)
-                          .withSupplyCurrentLimitEnable(SwerveConstants.DRIVE_ENABLE_CURRENT_LIMIT)
-                          .withStatorCurrentLimit(SwerveConstants.DRIVE_PEAK_CURRENT_LIMIT)
-                          .withStatorCurrentLimitEnable(
+                          .withSupplyCurrentLimitEnable(
                               SwerveConstants.DRIVE_ENABLE_CURRENT_LIMIT)))
           .withSteerMotorInitialConfigs(
               new TalonFXConfiguration()
@@ -172,7 +165,7 @@ public class DrivetrainIOCTRE extends SwerveDrivetrain implements DrivetrainIO {
               RobotConfig.getInstance().getSwerveConstants().getAngleGearRatio())
           .withWheelRadius(
               Units.metersToInches(RobotConfig.getInstance().getWheelDiameterMeters() / 2.0))
-          .withSlipCurrent(800)
+          .withSlipCurrent(SwerveConstants.DRIVE_PEAK_CURRENT_LIMIT)
           .withSteerMotorGains(steerGains)
           .withDriveMotorGains(driveGains)
           .withSteerMotorClosedLoopOutput(steerClosedLoopOutput)


### PR DESCRIPTION
instead of specifying current limits, which will be overwritten with the slip current value, just properly specify the slip current