### PR TITLE
handle case where the note is "lost" while in the note-in-kicker state

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -191,6 +191,13 @@ public class Intake extends SubsystemBase {
     if (inputs.isShooterIRBlocked) {
       intakeState = IntakeState.NOTE_IN_KICKER_AND_SHOOTER;
       this.turnKickerOff();
+    } else if (!inputs.isKickerIRBlocked) {
+      intakeState = IntakeState.EMPTY;
+      leds.requestState(LEDs.States.WAITING_FOR_GAME_PIECE);
+      this.intakeGamePiece();
+    } else if (inputs.isRollerIRBlocked) {
+      intakeState = IntakeState.NOTE_IN_INTAKE_AND_KICKER;
+      this.intakeGamePiece();
     }
   }
 


### PR DESCRIPTION
We didn't think this was physically possible, but we have observed it with the secondary roller IR sensor.