### PR TITLE
disable the deflector for TWIST

### DIFF
--- a/src/main/java/frc/robot/subsystems/shooter/ShooterConstants.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterConstants.java
@@ -11,7 +11,7 @@ public class ShooterConstants {
   public static final boolean DEBUGGING = false;
   public static final boolean TESTING = false;
   public static final String SUBSYSTEM_NAME = "Shooter";
-  public static final boolean DEFLECTOR_ENABLED = true;
+  public static final boolean DEFLECTOR_ENABLED = false;
 
   public static final boolean USE_MATHEMATICAL_MODEL = false;
 


### PR DESCRIPTION
since there isn't a deflector mounted on the robot, we don't want the motor constantly spinning